### PR TITLE
[Add] CustomData 스크립터블 오브젝트 생성 및 할당

### DIFF
--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scenes/WooSeok/Lobby Scene 2.unity
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scenes/WooSeok/Lobby Scene 2.unity
@@ -346,6 +346,7 @@ MonoBehaviour:
   hatRightButton: {fileID: 2085161590}
   confirmButton: {fileID: 578974316}
   playerIndex: 0
+  customData: {fileID: 11400000, guid: dfa5577dec2b2b042aa0836b6583e052, type: 2}
 --- !u!114 &370923342 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2487228349320114122, guid: afa6786cc3197624c8891889a2f98d32, type: 3}
@@ -395,6 +396,7 @@ MonoBehaviour:
   hatRightButton: {fileID: 25177992}
   confirmButton: {fileID: 745201242}
   playerIndex: 0
+  customData: {fileID: 11400000, guid: dfa5577dec2b2b042aa0836b6583e052, type: 2}
 --- !u!1 &393242451 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2487228349000045195, guid: afa6786cc3197624c8891889a2f98d32, type: 3}
@@ -823,6 +825,7 @@ MonoBehaviour:
   hatRightButton: {fileID: 395361719}
   confirmButton: {fileID: 1360386933}
   playerIndex: 0
+  customData: {fileID: 11400000, guid: dfa5577dec2b2b042aa0836b6583e052, type: 2}
 --- !u!1001 &497451330
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1341,6 +1344,7 @@ MonoBehaviour:
   hatRightButton: {fileID: 637952269}
   confirmButton: {fileID: 59787758}
   playerIndex: 0
+  customData: {fileID: 11400000, guid: dfa5577dec2b2b042aa0836b6583e052, type: 2}
 --- !u!1 &772900478
 GameObject:
   m_ObjectHideFlags: 0
@@ -2530,9 +2534,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b5b6af19112026241956bd54c2782536, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  roomName: {fileID: 1773552890}
   modelData: {fileID: 11400000, guid: 6fa241aaaf993ee46b96dd04dd5b99e9, type: 2}
   positionData: {fileID: 11400000, guid: bf6421970a8f14d44a5a373be836530b, type: 2}
+  roomName: {fileID: 1773552890}
   playerSlots:
   - {fileID: 0}
   - {fileID: 2487228348873077572}
@@ -2540,6 +2544,7 @@ MonoBehaviour:
   - {fileID: 2487228348873077570}
   - {fileID: 2487228348873077569}
   lobbyPlayerModels: []
+  modelBodyTextures: []
 --- !u!224 &2115222631 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2487228349300163905, guid: afa6786cc3197624c8891889a2f98d32, type: 3}

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/CustomizeCanvas.cs
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/CustomizeCanvas.cs
@@ -18,7 +18,7 @@ public class CustomizeCanvas : MonoBehaviourPunCallbacks
     [SerializeField] private Button confirmButton;
 
     [SerializeField] private int playerIndex; // 테스트 위해 SerializeField 추가함
-
+    [SerializeField] private CustomData customData;
     private PlayerModelChanger playerModelChanger;
     // WaitingRoomCanvas에 있는 GetPlayerModelChanger()함수를 통해서 스크립트를 받아와야함
     // 좀 자고 일어나서 하자

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/PlayerModelChanger.cs
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/PlayerModelChanger.cs
@@ -8,6 +8,7 @@ public class PlayerModelChanger : MonoBehaviourPunCallbacks
     [SerializeField] private GameObject currentHat; // 테스트 위해 SerializeField 추가함
     [SerializeField] private Transform hatTransform;
     [SerializeField] private Material bodyMaterial;
+    
 
     public Vector3 GetHatPosition()
     {

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/WaitingRoomCanvas.cs
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/1_Lobby Scene/Lobby/WaitingRoom Canvas/WaitingRoomCanvas.cs
@@ -8,9 +8,13 @@ using UnityEngine;
 public class WaitingRoomCanvas : MonoBehaviourPunCallbacks
 {
     private LobbyCanvases _lobbyCanvases;
-    [SerializeField] private TMP_Text roomName;
+    [Header("Data Scriptable Object")]
     [SerializeField] private ModelData modelData;
     [SerializeField] private PositionData positionData;
+
+
+    [Header("-------------------------------------------------------------------------------")]
+    [SerializeField] private TMP_Text roomName;
     [SerializeField] private PlayerSlot[] playerSlots;
 
     [SerializeField] private GameObject[] lobbyPlayerModels; // 테스트 위해 serializeFiled 부착

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/CustomData.cs
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/CustomData.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class CustomData : ScriptableObject
+{
+    public GameObject[] hats; // 7개
+
+    public Texture2D[] bodyColors; // 8개
+
+    /// <summary>
+    /// index에 따른 모자를 반환합니다
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public GameObject GetHatFromData(int index)
+    {
+        if (hats.Length <= index)
+        {
+            index = 0;
+        }
+        else if (index < 0)
+        {
+            index = hats.Length - 1;
+        }
+
+        return hats[index];
+    }
+
+    /// <summary>
+    /// index에 따른 texture2D를 반환합니다
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public Texture2D GetBodyColorFromData(int index)
+    {
+        if (hats.Length <= index)
+        {
+            index = 0;
+        }
+        else if (index < 0)
+        {
+            index = hats.Length - 1;
+        }
+
+        return bodyColors[index];   
+    }
+}

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/CustomData.cs.meta
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Scripts/CustomData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41e2c425097c4fe479647b104af24409
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Static GameObjects/Data/CustomData.asset
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Static GameObjects/Data/CustomData.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41e2c425097c4fe479647b104af24409, type: 3}
+  m_Name: CustomData
+  m_EditorClassIdentifier: 
+  hats:
+  - {fileID: 3321060860750121528, guid: 9356462f50c94bb4ab7c762a843ef19a, type: 3}
+  - {fileID: 7618390155671782634, guid: 39aa1dfbef3424d4c821ae1d15e96fa2, type: 3}
+  - {fileID: 3746582877025809737, guid: 0fcf7ea698ebb904198d123469cd2925, type: 3}
+  - {fileID: 2725994450096938899, guid: 5ade4d07db8f7bb408bbd5ad22d592c0, type: 3}
+  - {fileID: 3117598279901312015, guid: f6d1e48b34b99ea4584e0e6fc677f193, type: 3}
+  - {fileID: 6936470154947753270, guid: b888e1270e8f0564499f0b49b343e372, type: 3}
+  - {fileID: 2676589441665344323, guid: e673ac014002b7c4b9d6349943d00fad, type: 3}
+  bodyColors:
+  - {fileID: 2800000, guid: 38a784cd49415834bb6663e222303f1a, type: 3}
+  - {fileID: 2800000, guid: 39d2c53645bfdef43a17a85b6d32ef24, type: 3}
+  - {fileID: 2800000, guid: 10c022314f1e02742a8e8c43a6724efc, type: 3}
+  - {fileID: 2800000, guid: 3f2e98cdc5bd2fa478dea5ab1cd8ed7c, type: 3}
+  - {fileID: 2800000, guid: aed07d21f9a74ee4d8812379a81ab426, type: 3}
+  - {fileID: 2800000, guid: 3c09c1fcbb085454d98c3e00a26f278b, type: 3}
+  - {fileID: 2800000, guid: 3b93505d8743e324981a481663979160, type: 3}
+  - {fileID: 2800000, guid: c7fb407bdee368843b853dc3624c78f5, type: 3}

--- a/Team_Immortal Sprouts_Pummel Party/Assets/Static GameObjects/Data/CustomData.asset.meta
+++ b/Team_Immortal Sprouts_Pummel Party/Assets/Static GameObjects/Data/CustomData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dfa5577dec2b2b042aa0836b6583e052
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
몸 색깔과 모자를 할당받을 수 있는 CustomData 스크립터블 오브젝트를 생성 및 CustomizeCanvas에 할당함

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

마일스톤의 브랜치를 이용하기 위한 임시머지 